### PR TITLE
Fix to threshold_proba calculation for predict_proba functions

### DIFF
--- a/mord/tests/test_fit.py
+++ b/mord/tests/test_fit.py
@@ -2,7 +2,7 @@ import numpy as np
 from scipy import stats, optimize, sparse
 import mord
 import functools
-from nose.tools import assert_almost_equal, assert_less
+from nose.tools import assert_almost_equal, assert_greater_equal, assert_less
 
 np.random.seed(0)
 from sklearn import datasets, metrics, linear_model
@@ -114,3 +114,25 @@ def test_binary_class():
 #     clf1 = mord.LogisticAT()
 #     clf1.fit(X, y)
 #     assert_almost_equal(clf1.score(X, y) < )
+
+
+def test_predict_proba_nonnegative():
+    """
+    Test that predict_proba() function outputs a tuple of non-negative values
+    """
+
+    def check_for_negative_prob(proba):
+        for p in np.ravel(proba):
+            assert_greater_equal(np.round(p,7), 0)
+
+    clf = mord.LogisticAT(alpha=0.)
+    clf.fit(X, y)
+    check_for_negative_prob(clf.predict_proba(X))
+
+    clf2 = mord.LogisticIT(alpha=0.)
+    clf2.fit(X, y)
+    check_for_negative_prob(clf2.predict_proba(X))
+
+    clf3 = mord.LogisticSE(alpha=0.)
+    clf3.fit(X, y)
+    check_for_negative_prob(clf3.predict_proba(X))

--- a/mord/threshold_based.py
+++ b/mord/threshold_based.py
@@ -157,7 +157,7 @@ def threshold_proba(X, w, theta):
     """
     eta = theta[:, None] - np.asarray(X.dot(w), dtype=np.float64)
     prob = np.pad(
-        sigmoid(-eta).T,
+        sigmoid(eta).T,
         pad_width=((0, 0), (1, 1)),
         mode='constant',
         constant_values=(0, 1))


### PR DESCRIPTION
I believe I've found a small bug (#13) in the calculation of the threshold-based predict_proba functions. It's a sign error that ends up outputting negative probabilities in some cases. This pull request includes a regression test.