### PR TITLE
Allow pip install in a new environment - fixes #15

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -9,5 +9,5 @@ setup(
     author_email='f@bianp.net',
     url='https://pypi.python.org/pypi/mord',
     packages=['mord'],
-    requires=['numpy', 'scipy', "scikit-learn"],
+    requires=['numpy', 'scipy', "sklearn"],
 )

--- a/setup.py
+++ b/setup.py
@@ -1,14 +1,13 @@
 from setuptools import setup
-import mord
 
 setup(
     name='mord',
-    version=mord.__version__,
+    version="0.5",
     description='Ordinal regression models',
     long_description=open('README.rst').read(),
     author='Fabian Pedregosa',
     author_email='f@bianp.net',
     url='https://pypi.python.org/pypi/mord',
     packages=['mord'],
-    requires=['numpy', 'scipy'],
+    requires=['numpy', 'scipy', "scikit-learn"],
 )


### PR DESCRIPTION
Don't import the module to get the version number.
Pip can't discover the dependencies without them already being installed.
Also added sklearn as a dependency