### PR TITLE
Pandas has deprecated ".ix", so it has to be replaced with "iloc" in …

### DIFF
--- a/mord/datasets/base.py
+++ b/mord/datasets/base.py
@@ -46,9 +46,11 @@ def load_housing():
     each obs by index based on the number the frequency ('Freq')
     of appearance
     '''
+
+    # Pandas has deprecated ".ix", so it has to be replaced with "iloc"
     index = np.asarray(range(0, data.shape[0])).\
-        repeat(data.ix[:,'Freq'].values)
-    data = data.ix[index,:]
+        repeat(data['Freq'].values)
+    data = data.iloc[index,:]
     features = ('Infl', 'Type', 'Cont')
 
     return Bunch(data=data.loc[:,features],


### PR DESCRIPTION
…'base.py'

Also, are you sure the code for the example is correct?
When I inspect the values of

`clf4.predict(X)`
in housing.py, line 47, I get all "1"s predicted. Nevertheless, the accuracy is better than some of the other predictions.
