### PR TITLE
Update code to latest versions of packages

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,0 +1,21 @@
+name: build
+concurrency:
+  group: build-${{ github.ref }}
+  cancel-in-progress: true
+on: [push, workflow_dispatch]
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        python-version: ['3.8', '3.9', '3.10', '3.11']
+    name: Python ${{ matrix.python-version }} sample
+    steps:
+      - uses: actions/checkout@v2
+      - name: Set up Python
+        uses: actions/setup-python@v2
+        with:
+          python-version: ${{ matrix.python-version }}
+      - run: python --version
+      - run: pip install --upgrade pip nose numpy pandas scipy scikit-learn
+      - run: nosetests

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -17,5 +17,5 @@ jobs:
         with:
           python-version: ${{ matrix.python-version }}
       - run: python --version
-      - run: pip install --upgrade pip nose numpy pandas scipy scikit-learn
-      - run: nosetests
+      - run: pip install --upgrade pip pytest numpy pandas scipy scikit-learn
+      - run: pytest

--- a/mord/datasets/base.py
+++ b/mord/datasets/base.py
@@ -1,7 +1,7 @@
 from os.path import dirname, join
 
 import numpy as np
-from sklearn.datasets.base import Bunch
+from sklearn.utils import Bunch
 
 def load_housing():
     from pandas import read_csv

--- a/mord/datasets/tests/test_base.py
+++ b/mord/datasets/tests/test_base.py
@@ -1,6 +1,3 @@
-# from sklearn.utils.testing import assert_true
-# from sklearn.utils.testing import assert_equal
-
 from mord.datasets.base import load_housing
 
 
@@ -10,7 +7,3 @@ def test_load_housing():
     assert res.target.size == 1681
     assert len(res.feature_names) == 3
     assert res.DESCR
-    # assert_equal(res.data.shape, (1681, 3))
-    # assert_equal(res.target.size, 1681)
-    # assert_equal(len(res.feature_names), 3)
-    # assert_true(res.DESCR)

--- a/mord/datasets/tests/test_base.py
+++ b/mord/datasets/tests/test_base.py
@@ -1,12 +1,16 @@
-from sklearn.utils.testing import assert_true
-from sklearn.utils.testing import assert_equal
+# from sklearn.utils.testing import assert_true
+# from sklearn.utils.testing import assert_equal
 
 from mord.datasets.base import load_housing
 
 
 def test_load_housing():
     res = load_housing()
-    assert_equal(res.data.shape, (1681, 3))
-    assert_equal(res.target.size, 1681)
-    assert_equal(len(res.feature_names), 3)
-    assert_true(res.DESCR)
+    assert res.data.shape == (1681, 3)
+    assert res.target.size == 1681
+    assert len(res.feature_names) == 3
+    assert res.DESCR
+    # assert_equal(res.data.shape, (1681, 3))
+    # assert_equal(res.target.size, 1681)
+    # assert_equal(len(res.feature_names), 3)
+    # assert_true(res.DESCR)

--- a/mord/tests/test_fit.py
+++ b/mord/tests/test_fit.py
@@ -2,7 +2,8 @@ import numpy as np
 from scipy import stats, optimize, sparse
 import mord
 import functools
-from nose.tools import assert_almost_equal, assert_greater_equal, assert_less
+import pytest
+# from nose.tools import assert_almost_equal, assert_greater_equal, assert_less
 
 np.random.seed(0)
 from sklearn import datasets, metrics, linear_model
@@ -79,19 +80,15 @@ def test_grad():
         return mord.threshold_based.grad_margin(
             x, X, y, 100.0, n_class, loss_fd, L, sample_weights)
 
-    assert_less(
-        optimize.check_grad(fun, grad, x0),
-        1e-4,
-        msg='unweighted')
+    assert optimize.check_grad(fun, grad, x0) < 1e-4, 'unweighted'
 
     sample_weights = np.random.rand(n_samples)
-    assert_less(
+    assert (
         optimize.check_grad(
             functools.partial(fun, sample_weights=sample_weights),
             functools.partial(grad, sample_weights=sample_weights),
-            x0),
-        1e-4,
-        msg='weighted')
+            x0) < 1e-4
+    ), 'weighted'
 
 
 def test_binary_class():
@@ -103,12 +100,12 @@ def test_binary_class():
     clf = mord.LogisticAT(alpha=1e-6)
     clf.fit(Xc[:500], yc[:500])
     pred_at = clf.predict(Xc[500:])
-    assert_almost_equal(np.abs(pred_lr - pred_at).mean(), 0.)
+    assert np.abs(pred_lr - pred_at).mean() == pytest.approx(0)
 
     clf2 = mord.LogisticSE(alpha=1e-6)
     clf2.fit(Xc[:500], yc[:500])
     pred_at = clf2.predict(Xc[500:])
-    assert_almost_equal(np.abs(pred_lr - pred_at).mean(), 0.)
+    assert np.abs(pred_lr - pred_at).mean() == pytest.approx(0)
 
 # def test_performance():
 #     clf1 = mord.LogisticAT()
@@ -123,7 +120,7 @@ def test_predict_proba_nonnegative():
 
     def check_for_negative_prob(proba):
         for p in np.ravel(proba):
-            assert_greater_equal(np.round(p,7), 0)
+            assert np.round(p,7) >= 0
 
     clf = mord.LogisticAT(alpha=0.)
     clf.fit(X, y)

--- a/mord/tests/test_fit.py
+++ b/mord/tests/test_fit.py
@@ -3,7 +3,6 @@ from scipy import stats, optimize, sparse
 import mord
 import functools
 import pytest
-# from nose.tools import assert_almost_equal, assert_greater_equal, assert_less
 
 np.random.seed(0)
 from sklearn import datasets, metrics, linear_model

--- a/mord/threshold_based.py
+++ b/mord/threshold_based.py
@@ -186,7 +186,7 @@ class LogisticAT(base.BaseEstimator):
         self.max_iter = max_iter
 
     def fit(self, X, y, sample_weight=None):
-        _y = np.array(y).astype(int)
+        _y = np.array(y).astype(np.int)
         if np.abs(_y - y).sum() > 0.1:
             raise ValueError('y must only contain integer values')
         self.classes_ = np.unique(y)

--- a/mord/threshold_based.py
+++ b/mord/threshold_based.py
@@ -186,7 +186,7 @@ class LogisticAT(base.BaseEstimator):
         self.max_iter = max_iter
 
     def fit(self, X, y, sample_weight=None):
-        _y = np.array(y).astype(np.int)
+        _y = np.array(y).astype(int)
         if np.abs(_y - y).sum() > 0.1:
             raise ValueError('y must only contain integer values')
         self.classes_ = np.unique(y)

--- a/mord/threshold_based.py
+++ b/mord/threshold_based.py
@@ -146,7 +146,7 @@ def threshold_predict(X, w, theta):
     Class numbers are assumed to be between 0 and k-1
     """
     tmp = theta[:, None] - np.asarray(X.dot(w))
-    pred = np.sum(tmp < 0, axis=0).astype(np.int)
+    pred = np.sum(tmp < 0, axis=0).astype(int)
     return pred
 
 
@@ -186,7 +186,7 @@ class LogisticAT(base.BaseEstimator):
         self.max_iter = max_iter
 
     def fit(self, X, y, sample_weight=None):
-        _y = np.array(y).astype(np.int)
+        _y = np.array(y).astype(int)
         if np.abs(_y - y).sum() > 0.1:
             raise ValueError('y must only contain integer values')
         self.classes_ = np.unique(y)
@@ -242,7 +242,7 @@ class LogisticIT(base.BaseEstimator):
         self.max_iter = max_iter
 
     def fit(self, X, y, sample_weight=None):
-        _y = np.array(y).astype(np.int)
+        _y = np.array(y).astype(int)
         if np.abs(_y - y).sum() > 0.1:
             raise ValueError('y must only contain integer values')
         self.classes_ = np.unique(y)
@@ -297,7 +297,7 @@ class LogisticSE(base.BaseEstimator):
         self.max_iter = max_iter
 
     def fit(self, X, y, sample_weight=None):
-        _y = np.array(y).astype(np.int)
+        _y = np.array(y).astype(int)
         if np.abs(_y - y).sum() > 1e-3:
             raise ValueError('y must only contain integer values')
         self.classes_ = np.unique(y)


### PR DESCRIPTION
This PR addresses the following issues:

- `np.int` is deprecated
- Switch from `nose` to `pytest`: `nose` is no longer working in Python 3.10 and seems to be no longer updated
- Add code to run test across a variety of Python versions using Github actions (free for public repositories)

I use your package to demonstrate ordinal logistic regression in this book: https://www.amazon.com/Data-Mining-Business-Analytics-Applications/dp/1119549841
As this code in the book no longer works with recent versions of the Python packages, I would appreciate if you could release a new version of mord on pypi.